### PR TITLE
Fixed not showing plugin_TriggerClose_message

### DIFF
--- a/TriggerClose/pages/config.php
+++ b/TriggerClose/pages/config.php
@@ -98,7 +98,7 @@ if(isset($_SESSION['TriggerClose_flash_message'])) {
             <?php echo plugin_lang_get( 'note_when_closing' ) ?> 
        </td>
        <td>
-		<textarea name="message" cols="80" rows="10"><?php echo plugin_lang_get('note_text_when_closing') ?></textarea>
+		<textarea name="message" cols="80" rows="10"><?php echo plugin_config_get('message') ?></textarea>
        </td>
    </tr>
 


### PR DESCRIPTION
TriggerClose_message was showing the default text all the time instead of retrieving the actual saved message from the config